### PR TITLE
Update default EFI stub path

### DIFF
--- a/efi-mkuki
+++ b/efi-mkuki
@@ -41,7 +41,7 @@ fi
 
 PROGNAME='efi-mkuki'
 VERSION='0.1.0'
-EFISTUB_DIR='/usr/lib/gummiboot'
+EFISTUB_DIR='/usr/lib/systemd/boot/efi/'
 
 help() {
 	sed -n '/^#---help---/,/^#---help---/p' "$0" | sed 's/^# \?//; 1d;$d;'


### PR DESCRIPTION
This path is present on my Debian install, Fedora and in Arch Linux Wiki.