### PR TITLE
Calculate all section offsets dynamically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,6 @@ SED         := sed
 
 MAKEFILE_PATH  = $(lastword $(MAKEFILE_LIST))
 
-ifndef $(EFISTUB_DIR)
-  # If /usr/lib/systemd/boot/efi/ exists, rewrite /usr/lib/gummiboot to this.
-  ifneq ($(wildcard /usr/lib/systemd/boot/efi/.),)
-    EFISTUB_DIR := /usr/lib/systemd/boot/efi
-  endif
-endif
-
 
 #: Print list of targets.
 help:
@@ -27,7 +20,7 @@ help:
 install:
 	$(INSTALL) -d "$(DESTDIR)$(bindir)"
 	$(INSTALL) -m 755 $(SCRIPT_NAME) "$(DESTDIR)$(bindir)/$(SCRIPT_NAME)"
-	test -z "$(EFISTUB_DIR)" || $(SED) -i "s|/usr/lib/gummiboot|$(EFISTUB_DIR)|" "$(DESTDIR)$(bindir)/$(SCRIPT_NAME)"
+	test -z "$(EFISTUB_DIR)" || $(SED) -i "s|/usr/lib/systemd/boot/efi|$(EFISTUB_DIR)|" "$(DESTDIR)$(bindir)/$(SCRIPT_NAME)"
 
 #: Uninstall the script from $DESTDIR.
 uninstall:

--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@ To learn more about Secure Boot and why signing just a kernel image (when you us
 * http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html[POSIX-sh] compatible shell (e.g. Busybox ash, dash, ZSH, bash, …)
 * `awk`, `cat`, `grep`, `sed`, `tr` (BSD, Busybox or GNU)
 * `objcopy` and `objdump` from https://www.gnu.org/software/binutils/[GNU binutils]
-* EFI stub for your machine architecture from https://cgit.freedesktop.org/gummiboot/tree/?id=2bcd919c681c952eb867ef1bdb458f1bc49c2d55[gummiboot] footnote:[Gummiboot is referred to as obsolete because it was absorbed by systemd. Gummiboot EFI stubs are still useful though. You can download source tarball https://dev.alpinelinux.org/archive/gummiboot/gummiboot-48.1.tar.gz[gummiboot-48.1.tar.gz] (ff9a1632a82b1bef3434718e2aadca8783943f59) from Alpine Linux Archive.] or systemd
+* EFI stub for your machine architecture from https://www.freedesktop.org/software/systemd/man/latest/systemd-stub.html[systemd-stub], https://github.com/puzzleos/stubby[Stubby bootloader] or similar
 
 
 == Installation
@@ -51,7 +51,7 @@ make install DESTDIR=/ prefix=/usr/local
 
 ...or just download the link:https://raw.githubusercontent.com/{gh-name}/master/{proj-name}[{proj-name}] script directly.
 
-*NOTE*: {proj-name} expects EFI stubs in `/usr/lib/gummiboot`. This can be rewritten to another path via `EFISTUB_DIR` variable passed to `make install`. If `/usr/lib/systemd/boot/efi/` directory exists, `make install` will use it automatically.
+*NOTE*: {proj-name} expects EFI stubs in `/usr/lib/systemd/boot/efi`. This can be rewritten to another path via `EFISTUB_DIR` variable passed to `make install`.
 
 
 == Usage

--- a/README.adoc
+++ b/README.adoc
@@ -14,8 +14,8 @@ To learn more about Secure Boot and why signing just a kernel image (when you us
 == Requirements
 
 * http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html[POSIX-sh] compatible shell (e.g. Busybox ash, dash, ZSH, bash, …)
-* `cat`, `grep`, `sed`, `tr` (BSD, Busybox or GNU)
-* `objcopy` from https://www.gnu.org/software/binutils/[GNU binutils]
+* `awk`, `cat`, `grep`, `sed`, `tr` (BSD, Busybox or GNU)
+* `objcopy` and `objdump` from https://www.gnu.org/software/binutils/[GNU binutils]
 * EFI stub for your machine architecture from https://cgit.freedesktop.org/gummiboot/tree/?id=2bcd919c681c952eb867ef1bdb458f1bc49c2d55[gummiboot] footnote:[Gummiboot is referred to as obsolete because it was absorbed by systemd. Gummiboot EFI stubs are still useful though. You can download source tarball https://dev.alpinelinux.org/archive/gummiboot/gummiboot-48.1.tar.gz[gummiboot-48.1.tar.gz] (ff9a1632a82b1bef3434718e2aadca8783943f59) from Alpine Linux Archive.] or systemd
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -14,7 +14,7 @@ To learn more about Secure Boot and why signing just a kernel image (when you us
 == Requirements
 
 * http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html[POSIX-sh] compatible shell (e.g. Busybox ash, dash, ZSH, bash, …)
-* `awk`, `cat`, `grep`, `sed`, `tr` (BSD, Busybox or GNU)
+* `awk`, `cat`, `dd`, `grep`, `od`, `sed`, `tr` (BSD, Busybox or GNU)
 * `objcopy` and `objdump` from https://www.gnu.org/software/binutils/[GNU binutils]
 * EFI stub for your machine architecture from https://www.freedesktop.org/software/systemd/man/latest/systemd-stub.html[systemd-stub], https://github.com/puzzleos/stubby[Stubby bootloader] or similar
 

--- a/efi-mkuki
+++ b/efi-mkuki
@@ -41,7 +41,7 @@ fi
 
 PROGNAME='efi-mkuki'
 VERSION='0.1.1'
-EFISTUB_DIR='/usr/lib/gummiboot'
+EFISTUB_DIR='/usr/lib/systemd/boot/efi'
 ALIGNMENT=4096  # bytes
 
 help() {

--- a/efi-mkuki
+++ b/efi-mkuki
@@ -42,6 +42,7 @@ fi
 PROGNAME='efi-mkuki'
 VERSION='0.1.1'
 EFISTUB_DIR='/usr/lib/gummiboot'
+ALIGNMENT=4096  # bytes
 
 help() {
 	sed -n '/^#---help---/,/^#---help---/p' "$0" | sed 's/^# \?//; 1d;$d;'
@@ -52,11 +53,22 @@ die() {
 	exit 2
 }
 
+# Prints value of the specified variable $1.
+getval() {
+	eval "printf '%s\n' \"\$$1\""
+}
+
+# Calculate the next offset by aligning the size $2 to the $ALIGNMENT boundary
+# and adding the current offset $1.
+next_offset() {
+	printf '%d' "$(( $1 + ( ($2 + $ALIGNMENT - 1) / $ALIGNMENT * $ALIGNMENT) ))"
+}
+
 # Defaults
 cmdline=/proc/cmdline
 output=
 osrel=/etc/os-release
-splash=/dev/null
+splash=
 efistub=
 
 while getopts ':c:o:r:s:S:hV' OPT; do
@@ -98,14 +110,6 @@ cmdline="$tmpdir/cmdline"
 
 linux=$1; shift
 
-# Kernel sizes can sometimes be larger than 16MiB; cacluate a safe location for
-# the initrd.
-kernel_offset='0x2000000'
-kernel_size="$(stat -c '%s' "$linux")"
-# Initrd offset is the first page-aligned (0x...000) address that's 0x1000000
-# (16MiB) from the end of the kernel.
-initrd_offset="0x$(printf '%x\n' "$(( ( 1 + ( 0x1000000 + $kernel_offset + $kernel_size ) / 0x1000) * 0x1000 ))")"
-
 initrd=${1:-"/dev/null"}
 if [ $# -gt 1 ]; then
 	initrd="$tmpdir/initrd"
@@ -114,13 +118,29 @@ fi
 
 [ "$output" ] || output="$linux.efi"
 
-objcopy \
-	--add-section .osrel="$osrel"     --change-section-vma .osrel=0x20000 \
-	--add-section .cmdline="$cmdline" --change-section-vma .cmdline=0x30000 \
-	--add-section .splash="$splash"   --change-section-vma .splash=0x40000 \
-	--add-section .linux="$linux"     --change-section-vma ".linux=$kernel_offset"  \
-	--add-section .initrd="$initrd"   --change-section-vma ".initrd=$initrd_offset" \
-	"$efistub" "$output"
+# Take the size and offset of the last EFI stub section to compute the next
+# section offset.
+offset="$(objdump -h -w "$efistub" | awk 'END {
+	vma = ("0x"$4) + 0;
+	size = ("0x"$3) + 0;
+	print vma + size
+}')"
+test "$offset" -eq "$offset" 2>/dev/null \
+	|| die 'failed to resolve EFI stub offset!'
+offset="$(next_offset 0 "$offset")"  # align offset
+
+objcopy_opts=''
+for section in osrel cmdline splash linux initrd; do
+	filename="$(getval "$section")"
+	[ "$filename" ] || continue
+
+	objcopy_opts="$objcopy_opts --add-section \".$section=$filename\" --change-section-vma \".$section=$offset\""
+	size="$(stat -Lc '%s' "$filename")"
+	offset="$(next_offset "$offset" "$size")"
+done
+
+eval set -- "$objcopy_opts"
+objcopy "$@" "$efistub" "$output"
 
 # This corrects putting sections below the base image of the stub.
 objcopy --adjust-vma 0 "$output"

--- a/efi-mkuki
+++ b/efi-mkuki
@@ -1,7 +1,7 @@
 #!/bin/sh
 # vim: set ts=4:
 #---help---
-# Usage: efi-mkuki [options] -k <kver> <vmlinuz> [<microcode>...] [<initrd>]
+# Usage: efi-mkuki [options] <vmlinuz> [<microcode>...] [<initrd>]
 #        efi-mkuki <-h | -V>
 #
 # Create an EFI Unified Kernel Image (UKI) - a single EFI PE executable
@@ -19,7 +19,8 @@
 #
 #   -k <version | file>  Kernel release ("uname -r" information), or location of
 #                        file with kernel release (if begins with "/" or ".").
-#                        This option is REQUIRED.
+#                        This is optional on x86 and x86_64 (if not specified,
+#                        it's parsed from <vmlinuz>), but required on others.
 #
 #   -o <file>            Write output into <file>. Defaults to <vmlinuz>.efi.
 #
@@ -68,6 +69,19 @@ next_offset() {
 	printf '%d' "$(( $1 + ( ($2 + $ALIGNMENT - 1) / $ALIGNMENT * $ALIGNMENT) ))"
 }
 
+kver_x86() {
+	local vmlinuz="$1"
+	# https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/blob/a6ef10d3f4f24029fc649686ba36f692d8575a7a/functions#L142-162
+	# https://www.kernel.org/doc/html/v6.7/arch/x86/boot.html
+	# https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/boot/header.S?h=v6.7
+	local offset; offset="$(od -An -j0x20E -dN2 "$vmlinuz")" || return
+	local kver="$(dd if="$vmlinuz" bs=1 count=127 skip="$(($offset + 0x200))" 2>/dev/null)"
+
+	# Read the first word from this string as the kernel version.
+	printf '%s' "${kver%% *}"
+}
+
+
 # Defaults
 cmdline=/proc/cmdline
 output=
@@ -92,7 +106,6 @@ done
 shift $((OPTIND - 1))
 
 [ $# -ge 1 ] || die "invalid number of arguments, see '$PROGNAME -h'"
-[ "$kver" ] || die 'missing required option -k'
 
 if ! [ "$efistub" ]; then
 	case "$(uname -m)" in
@@ -115,16 +128,20 @@ case "$cmdline" in
 esac
 cmdline="$tmpdir/cmdline"
 
+linux=$1; shift
+
 uname="$tmpdir/uname"
 case "$kver" in
+	'') case "$(uname -m)" in
+	    	i686 | x86 | x86_64) kver_x86 "$linux";;
+	    	*) die 'missing required option -k';;
+	    esac ;;
 	/* | .*) head -n 1 "$kver";;
 	*) printf '%s\n' "$kver";;
 esac > "$uname"
 
 grep -q '^[0-9]\+\.[0-9][0-9A-Za-z_.-]*$' "$uname" \
 	|| die "invalid kernel version (-k): $(cat "$uname")"
-
-linux=$1; shift
 
 initrd=${1:-"/dev/null"}
 if [ $# -gt 1 ]; then

--- a/efi-mkuki
+++ b/efi-mkuki
@@ -1,7 +1,7 @@
 #!/bin/sh
 # vim: set ts=4:
 #---help---
-# Usage: efi-mkuki [options] <vmlinuz> [<microcode>...] [<initrd>]
+# Usage: efi-mkuki [options] -k <kver> <vmlinuz> [<microcode>...] [<initrd>]
 #        efi-mkuki <-h | -V>
 #
 # Create an EFI Unified Kernel Image (UKI) - a single EFI PE executable
@@ -16,6 +16,10 @@
 # Options:
 #   -c <cmdline | file>  Kernel cmdline, or location of file with kernel cmdline
 #                        (if begins with "/" or "."). Defaults to /proc/cmdline.
+#
+#   -k <version | file>  Kernel release ("uname -r" information), or location of
+#                        file with kernel release (if begins with "/" or ".").
+#                        This option is REQUIRED.
 #
 #   -o <file>            Write output into <file>. Defaults to <vmlinuz>.efi.
 #
@@ -70,10 +74,12 @@ output=
 osrel=/etc/os-release
 splash=
 efistub=
+kver=
 
-while getopts ':c:o:r:s:S:hV' OPT; do
+while getopts ':c:k:o:r:s:S:hV' OPT; do
 	case "$OPT" in
 		c) cmdline=$OPTARG;;
+		k) kver=$OPTARG;;
 		o) output=$OPTARG;;
 		r) osrel=$OPTARG;;
 		s) splash=$OPTARG;;
@@ -86,6 +92,7 @@ done
 shift $((OPTIND - 1))
 
 [ $# -ge 1 ] || die "invalid number of arguments, see '$PROGNAME -h'"
+[ "$kver" ] || die 'missing required option -k'
 
 if ! [ "$efistub" ]; then
 	case "$(uname -m)" in
@@ -107,6 +114,15 @@ case "$cmdline" in
 	*) printf '%s\n' "$cmdline" > "$tmpdir"/cmdline;;
 esac
 cmdline="$tmpdir/cmdline"
+
+uname="$tmpdir/uname"
+case "$kver" in
+	/* | .*) head -n 1 "$kver";;
+	*) printf '%s\n' "$kver";;
+esac > "$uname"
+
+grep -q '^[0-9]\+\.[0-9][0-9A-Za-z_.-]*$' "$uname" \
+	|| die "invalid kernel version (-k): $(cat "$uname")"
 
 linux=$1; shift
 
@@ -130,7 +146,7 @@ test "$offset" -eq "$offset" 2>/dev/null \
 offset="$(next_offset 0 "$offset")"  # align offset
 
 objcopy_opts=''
-for section in osrel cmdline splash linux initrd; do
+for section in uname osrel cmdline splash linux initrd; do
 	filename="$(getval "$section")"
 	[ "$filename" ] || continue
 


### PR DESCRIPTION
The current implementation with fixed offsets doesn't work with larger EFI stubs such as systemd-efistub.

Based on #6

Resolves #4